### PR TITLE
fix: #606 by converting hex string to bytes directly

### DIFF
--- a/src/accounts/utils/signMessage.test.ts
+++ b/src/accounts/utils/signMessage.test.ts
@@ -22,4 +22,14 @@ test('default', async () => {
   ).toMatchInlineSnapshot(
     '"0x05c99bbbe9fac3ad61721a815d19d6771ad39f3e8dffa7ae7561358f20431d8e7f9e1d487c77355790c79c6eb0b0d63690f690615ef99ee3e4f25eef0317d0701b"',
   )
+
+  expect(
+    await signMessage({
+      message:
+        '0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b',
+      privateKey: accounts[0].privateKey,
+    }),
+  ).toMatchInlineSnapshot(
+    '"0x1a7fd732f926be0a1dbfd1b4acbd7a6f7198fda1ab5ef69ef027a2eee89987785d210298e12119a1d62b5a7d2d9f24d075682675ae00f51a5602e725f0d180851b"',
+  )
 })

--- a/src/utils/encoding/toBytes.test.ts
+++ b/src/utils/encoding/toBytes.test.ts
@@ -1042,6 +1042,46 @@ describe('converts string to bytes', () => {
       ]
     `,
     )
+    expect(
+      stringToBytes(
+        '0xa70d0af2ebb03a44dcd0714a8724f622e3ab876d0aa312f0ee04823285d6fb1b',
+      ),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        167,
+        13,
+        10,
+        242,
+        235,
+        176,
+        58,
+        68,
+        220,
+        208,
+        113,
+        74,
+        135,
+        36,
+        246,
+        34,
+        227,
+        171,
+        135,
+        109,
+        10,
+        163,
+        18,
+        240,
+        238,
+        4,
+        130,
+        50,
+        133,
+        214,
+        251,
+        27,
+      ]
+    `)
   })
 
   test('args: size', () => {

--- a/src/utils/encoding/toBytes.ts
+++ b/src/utils/encoding/toBytes.ts
@@ -183,6 +183,10 @@ export function stringToBytes(
   value: string,
   opts: StringToBytesOpts = {},
 ): ByteArray {
+  if (isHex(value)) {
+    return hexToBytes(value, opts)
+  }
+
   const bytes = encoder.encode(value)
   if (typeof opts.size === 'number') {
     assertSize(bytes, { size: opts.size })


### PR DESCRIPTION
This fixes https://github.com/wagmi-dev/viem/issues/606 by checking if the string passed to stringToBytes is a hex string already, and, if it is, converting it to a byte array directly instead of UTF-8 encoding the string.
