### PR TITLE
feat: add support for resolving ens addresses using coinType

### DIFF
--- a/.changeset/quick-colts-flow.md
+++ b/.changeset/quick-colts-flow.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added coin type support for `getEnsAddress`.

--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -70,19 +70,6 @@ const ensName = await publicClient.getEnsAddress({
 })
 ```
 
-### coinType
-
-- **Type:** `bigint`
-
-The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multichain-address-resolution) coin type to fetch the address for
-
-```ts
-const ensName = await publicClient.getEnsAddress({
-  name: normalize('wagmi-dev.eth'), 
-  coinType: 60, // [!code focus]
-})
-```
-
 ### blockNumber (optional)
 
 - **Type:** `number`
@@ -107,6 +94,19 @@ The block tag to perform the read against.
 const ensName = await publicClient.getEnsAddress({
   name: normalize('wagmi-dev.eth'),
   blockTag: 'safe', // [!code focus]
+})
+```
+
+### coinType (optional)
+
+- **Type:** `bigint`
+
+The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multichain-address-resolution) coin type to fetch the address for
+
+```ts
+const ensName = await publicClient.getEnsAddress({
+  name: normalize('wagmi-dev.eth'), 
+  coinType: 60, // [!code focus]
 })
 ```
 

--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -70,6 +70,19 @@ const ensName = await publicClient.getEnsAddress({
 })
 ```
 
+### coinType
+
+- **Type:** `bigint`
+
+The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multichain-address-resolution) coin type to fetch the address for
+
+```ts
+const ensName = await publicClient.getEnsAddress({
+  name: normalize('wagmi-dev.eth'), 
+  coinType: 60n, // [!code focus]
+})
+```
+
 ### blockNumber (optional)
 
 - **Type:** `number`

--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -79,7 +79,7 @@ The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multich
 ```ts
 const ensName = await publicClient.getEnsAddress({
   name: normalize('wagmi-dev.eth'), 
-  coinType: 60n, // [!code focus]
+  coinType: 60, // [!code focus]
 })
 ```
 

--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -99,7 +99,7 @@ const ensName = await publicClient.getEnsAddress({
 
 ### coinType (optional)
 
-- **Type:** `bigint`
+- **Type:** `number`
 
 The [ENSIP-9](https://docs.ens.domains/ens-improvement-proposals/ensip-9-multichain-address-resolution) coin type to fetch the address for
 

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -27,7 +27,7 @@ test('gets address for name', async () => {
 
 test('gets address for name with coinType', async () => {
   await expect(
-    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 60n }),
+    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 60 }),
   ).resolves.toMatchInlineSnapshot(
     '"0xa0cf798816d4b9b9866b5330eea46a18382f251e"',
   )
@@ -35,7 +35,7 @@ test('gets address for name with coinType', async () => {
 
 test('name without address with coinType', async () => {
   await expect(
-    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 61n }),
+    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 61 }),
   ).resolves.toBeNull()
 })
 

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -25,6 +25,20 @@ test('gets address for name', async () => {
   )
 })
 
+test('gets address for name with coinType', async () => {
+  await expect(
+    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 60n }),
+  ).resolves.toMatchInlineSnapshot(
+    '"0xa0cf798816d4b9b9866b5330eea46a18382f251e"',
+  )
+})
+
+test('name without address with coinType', async () => {
+  await expect(
+    getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 61n }),
+  ).resolves.toBeNull()
+})
+
 test('name without address', async () => {
   await expect(
     getEnsAddress(publicClient, { name: 'another-unregistered-name.eth' }),

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -23,10 +23,10 @@ import {
 
 export type GetEnsAddressParameters = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
-    /** Name to get the address for. */
-    name: string
     /** ENSIP-9 compliant coinType used to resolve addresses for other chains */
     coinType?: number
+    /** Name to get the address for. */
+    name: string
     /** Address of ENS Universal Resolver Contract. */
     universalResolverAddress?: Address
   }
@@ -67,8 +67,8 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
   {
     blockNumber,
     blockTag,
-    name,
     coinType,
+    name,
     universalResolverAddress: universalResolverAddress_,
   }: GetEnsAddressParameters,
 ): Promise<GetEnsAddressReturnType> {

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -115,10 +115,8 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
       }),
     )
 
-    if (address === '0x00' || address === '0x') {
-      return null
-    }
-
+    if (address === '0x') return null
+    if (trim(address) === '0x00') return null
     return address
   } catch (err) {
     if (isNullUniversalResolverError(err, 'resolve')) return null

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -102,7 +102,7 @@ export const textResolverAbi = [
   },
 ] as const
 
-export const singleAddressResolverAbi = [
+export const addressResolverAbi = [
   {
     name: 'addr',
     type: 'function',
@@ -110,9 +110,6 @@ export const singleAddressResolverAbi = [
     inputs: [{ name: 'name', type: 'bytes32' }],
     outputs: [{ name: '', type: 'address' }],
   },
-] as const
-
-export const coinTypeAddressResolverAbi = [
   {
     name: 'addr',
     type: 'function',

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -112,6 +112,19 @@ export const singleAddressResolverAbi = [
   },
 ] as const
 
+export const coinTypeAddressResolverAbi = [
+  {
+    name: 'addr',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'name', type: 'bytes32' },
+      { name: 'coinType', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bytes' }],
+  },
+] as const
+
 // ERC-1271
 // isValidSignature(bytes32 hash, bytes signature) → bytes4 magicValue
 export const smartAccountAbi = [


### PR DESCRIPTION
This adds support for ENSIP-9 resolution of addresses other than mainnet. 

the current ENS resolver also supports addr(name, coinType). So this adds that support to the getEnsAddress function
